### PR TITLE
fix: 稀に1秒飛んで表示されるバグを修正

### DIFF
--- a/js/clock.js
+++ b/js/clock.js
@@ -74,7 +74,10 @@
         document.getElementById('RFCClock').innerHTML = minute1 + ":" + second;
         document.getElementById('Calendar').innerHTML = "現在時刻" + "  " + year + "/" + month + "/" + date + " " + hour +
             ":" + minute2 + ":" + second;
-        window.setTimeout("clock()", 1000);
+
+        var now_ms = now.getMilliseconds();
+        var timeUntilNextSec_ms = 1000 - now_ms;
+        window.setTimeout("clock()", timeUntilNextSec_ms);
     }
     window.onload = clock;
     window.addEventListener('load', function () {


### PR DESCRIPTION
現状のコードだと、常に「表示更新から1000ms後に次の表示更新を行う」という処理になってしまっており、このため以下の理由で表示時刻にズレが生じます。

- そもそも表示した時間が0.000秒ではない
- タスクスイッチ等の影響で、きっちり1000ms後に実行されるわけではない  
  手元の環境 (macOS + Chrome) では、1秒ごとに概ね1ms ~ 3msほどの遅延が発生しました (下の画像参照)

![遅延が増えていっている様子](https://github.com/railway-fan-club/rfc-clock/assets/31824852/7b2dde4e-c67f-4b19-a940-e9af398f97f6)
(`setTimeout("clock()", 1000)` を実行する直前に `now.getMilliseconds()` を実行し、その結果を出力している様子)

そして、特に後者の影響により、時々1秒飛んで表示されてしまいます。
例えば、2ms/秒の遅延だと、500秒 = 8分ちょいごとに1秒飛ぶことになります。

そこまで影響が大きいわけではないですが、時計を注視しているとどうしても違和感を感じてしまいます。

---

そこで、「次に秒が進むまでの時間[ms]」だけ `setTimeout` に渡すことで、なるべく正確に端末の時刻を表示するようにしました。  
適用後の `now.getMilliseconds()` (端末時刻と表示時刻のズレ) は、下の画像のように3ms ~ 6msまで減少しています。

![端末時刻からのズレが1桁msに収まっている様子](https://github.com/railway-fan-club/rfc-clock/assets/31824852/8f26f0e1-6f04-42d3-b5d3-bea825fcdb52)

まだ最大6msの遅延はありますが、これ以上は人間が知覚できないと思われるため、十分であると思っています。

---

このPRの適用により、より「端末時刻を正確に合わせること」の重要性は増大しましたが、これについてはいつか「`now` に任意時間のdelayを適用できるようにする機能」を実装すれば問題なくなると思っています。