### PR TITLE
1日の長さを変更できるようにする

### DIFF
--- a/js/clock.js
+++ b/js/clock.js
@@ -40,12 +40,12 @@
      */
     function getParamWithLocalStorage(name) {
         const paramValue = getParam(name);
-        if (paramValue) {
+        if (paramValue != null) {
             console.log(name, paramValue);
-            localStorage[name] = paramValue;
+            localStorage.setItem(name, paramValue);
             return paramValue;
         } else {
-            const storedValue = localStorage[name];
+            const storedValue = localStorage.getItem(name);
             console.log(name, storedValue, "(stored)");
             return storedValue;
         }

--- a/js/clock.js
+++ b/js/clock.js
@@ -12,9 +12,9 @@
 
     // modelTotalSecでの日付変更時刻[模型秒]
     // 例: 15 * 60 * 60 は模型時刻15:00:00
-    const DEFAULT_TIME_LEN_S = 3 * 60 * 60
+    const DEFAULT_TIME_LEN_S = 3 * 60 * 60;
     
-    const DEFAULT_TIME_MULTIPLIER = 60
+    const DEFAULT_TIME_MULTIPLIER = 60;
 
     /**
      * Get the URL parameter value
@@ -48,18 +48,11 @@
         }
     }
 
-    var delay = 0;
-    if (getParam(PARAM_NAME_DELAY) !== null) {
-        delay = getParam(PARAM_NAME_DELAY);
-    }
     //特殊モード（秩父夜祭花火用）
-    var event = null;
-    if (getParam(PARAM_NAME_EVENT) !== null) {
-        event = getParam(PARAM_NAME_EVENT);
-    }
+    var eventMode = getParamWithLocalStorage(PARAM_NAME_EVENT) || "";
 
-    const timeLen_ModelS = getParam(PARAM_NAME_TIME_LEN) || Number(localStorage.getItem(PARAM_NAME_TIME_LEN)) || DEFAULT_TIME_LEN_S;
-    const timeMultiplier = getParam(PARAM_NAME_TIME_MULTIPLIER) || Number(localStorage.getItem(PARAM_NAME_TIME_MULTIPLIER)) || DEFAULT_TIME_MULTIPLIER;
+    const timeLen_ModelS = Number(getParamWithLocalStorage(PARAM_NAME_TIME_LEN)) || DEFAULT_TIME_LEN_S;
+    const timeMultiplier = Number(getParamWithLocalStorage(PARAM_NAME_TIME_MULTIPLIER)) || DEFAULT_TIME_MULTIPLIER;
 
     /**
      * 模型時刻での現在時刻を模型秒単位で取得する
@@ -90,17 +83,15 @@
 
     //打ち上げ開始時刻
     var hanabi_start = 18;
-    var minute1; //グローバル変数に昇格
+    // イベント管理用 模型時刻[時] を格納する変数
+    var minute1 = 0;
+    var isInfoTextSet = false;
     function clock() {
-        var param = location.search;
-        var infotext = '';
-        if (getParam(PARAM_NAME_INFOTEXT) !== null) {
-            infotext = getParam(PARAM_NAME_INFOTEXT);
+        if (!isInfoTextSet) {
+            const infotext = getParamWithLocalStorage(PARAM_NAME_INFOTEXT) || "";
+            document.getElementById('infotext').innerHTML = infotext;
+            isInfoTextSet = true;
         }
-
-        document.getElementById('infotext').innerHTML = decodeURI(infotext);
-
-        var delay_button;
         const now = new Date();
         const year = now.getFullYear();
         const month = numPad(now.getMonth() + 1);
@@ -114,6 +105,7 @@
         const modelMinuteNum = Math.abs(Math.floor((modelTotalSec / 60) % 60));
         const modelHour = numPad(modelHourNum);
         const modelMinute = numPad(modelMinuteNum);
+        minute1 = modelHourNum;
 
         document.getElementById('RFCClock').innerHTML = `${modelHour}:${modelMinute}`;
         document.getElementById('Calendar').innerHTML = `現在時刻 ${year}/${month}/${date} ${hour}:${minute}:${second}`;
@@ -122,15 +114,7 @@
         const timeUntilNextSec_ms = (1000 - now_ms) / (Math.max(timeMultiplier, 60) / 60);
         window.setTimeout("clock()", timeUntilNextSec_ms);
     }
-    window.onload = clock;
     window.addEventListener('load', function () {
-        delay_button = document.getElementById("RFCClock");
-        // delay_button.onclick = function () {
-        // 	if (delay <= 30) {
-        // 		delay = delay + 5;
-        // 	} else {
-        // 		delay = delay - 25;
-        // 	}
-        // }
+        clock();
     })
 }

--- a/js/clock.js
+++ b/js/clock.js
@@ -12,7 +12,7 @@
 
     // modelTotalSecでの日付変更時刻[模型秒]
     // 例: 15 * 60 * 60 は模型時刻15:00:00
-    const DEFAULT_TIME_LEN_S = 3 * 60 * 60;
+    const DEFAULT_TIME_LEN_S = 30 * 60 * 60;
     
     const DEFAULT_TIME_MULTIPLIER = 60;
 

--- a/js/clock.js
+++ b/js/clock.js
@@ -5,6 +5,16 @@
     const PARAM_NAME_EVENT = "event";
     /** 下部に表示する案内メッセージ */
     const PARAM_NAME_INFOTEXT = "infotext";
+    /** 模型時刻での1日の長さ[秒] */
+    const PARAM_NAME_TIME_LEN = "time-len";
+    /** 現実1秒で模型時刻がどれくらい進むか[現実秒] */
+    const PARAM_NAME_TIME_MULTIPLIER = "time-multiplier";
+
+    // modelTotalSecでの日付変更時刻[模型秒]
+    // 例: 15 * 60 * 60 は模型時刻15:00:00
+    const DEFAULT_TIME_LEN_S = 3 * 60 * 60
+    
+    const DEFAULT_TIME_MULTIPLIER = 60
 
     /**
      * Get the URL parameter value
@@ -22,6 +32,21 @@
         if (!results[2]) return '';
         return decodeURIComponent(results[2].replace(/\+/g, " "));
     }
+    /**
+     * URLパラメータから値を取得するか、パラメータが指定されていなければローカルストレージから取得する
+     * URLパラメータが指定されていた場合、それをローカルストレージに保存する
+     * 
+     * @param {string} name パラメータ名
+     */
+    function getParamWithLocalStorage(name) {
+        const paramValue = getParam(name);
+        if (paramValue) {
+            localStorage[name] = paramValue
+            return paramValue
+        } else {
+            return localStorage[name]
+        }
+    }
 
     var delay = 0;
     if (getParam(PARAM_NAME_DELAY) !== null) {
@@ -31,6 +56,36 @@
     var event = null;
     if (getParam(PARAM_NAME_EVENT) !== null) {
         event = getParam(PARAM_NAME_EVENT);
+    }
+
+    const timeLen_ModelS = getParam(PARAM_NAME_TIME_LEN) || Number(localStorage.getItem(PARAM_NAME_TIME_LEN)) || DEFAULT_TIME_LEN_S;
+    const timeMultiplier = getParam(PARAM_NAME_TIME_MULTIPLIER) || Number(localStorage.getItem(PARAM_NAME_TIME_MULTIPLIER)) || DEFAULT_TIME_MULTIPLIER;
+
+    /**
+     * 模型時刻での現在時刻を模型秒単位で取得する
+     * @param {boolean} withMilliSec ミリ秒まで取得するかどうか
+     * @returns {number} 模型時刻での現在時刻[模型秒]
+     */
+    function getModelTotalSec(withMilliSec = false) {
+        const now = new Date();
+        const realHour = timeMultiplier < 30 ? now.getHours() : 0;
+        const realMinute = now.getMinutes();
+        const realSecond = now.getSeconds();
+        const realMilliSec = withMilliSec ? now.getMilliseconds() : 0;
+        const realTotalSec = realHour * 3600 + realMinute * 60 + realSecond + realMilliSec / 1000;
+        const modelTotalSec = (realTotalSec * timeMultiplier) % timeLen_ModelS;
+        return modelTotalSec;
+    }
+
+    /**
+     * 指定桁数までゼロ埋めした文字列を取得する
+     * 
+     * @param {number} num ゼロ埋めしたい数値
+     * @param {number} length ゼロ埋め後の桁数
+     * @returns {string} ゼロ埋めした文字列
+     */
+    function numPad(num, length = 2) {
+        return ("0000000000" + num).slice(-length);
     }
 
     //打ち上げ開始時刻
@@ -46,45 +101,25 @@
         document.getElementById('infotext').innerHTML = decodeURI(infotext);
 
         var delay_button;
-        var now = new Date();
-        var year = now.getFullYear();
-        var month = now.getMonth() + 1;
-        var date = now.getDate();
-        var hour = now.getHours();
-        minute1 = now.getMinutes();
-        var minute2 = now.getMinutes();
-        var second = now.getSeconds();
-        minute1 = minute1 - delay;
-        if (month < 10) {
-            month = "0" + month;
-        }
-        if (date < 10) {
-            date = "0" + date;
-        }
-        if (hour < 10) {
-            hour = "0" + hour;
-        }
-        if (minute1 > 29) {
-            minute1 = minute1 - 30;
-        }
-        if (minute1 < 0) {
-            minute1 = minute1 + 30;
-        }
-        if (minute1 < 10) {
-            minute1 = "0" + minute1;
-        }
-        if (minute2 < 10) {
-            minute2 = "0" + minute2;
-        }
-        if (second < 10) {
-            second = "0" + second;
-        }
-        document.getElementById('RFCClock').innerHTML = minute1 + ":" + second;
-        document.getElementById('Calendar').innerHTML = "現在時刻" + "  " + year + "/" + month + "/" + date + " " + hour +
-            ":" + minute2 + ":" + second;
+        const now = new Date();
+        const year = now.getFullYear();
+        const month = numPad(now.getMonth() + 1);
+        const date = numPad(now.getDate());
+        const hour = numPad(now.getHours());
+        const minute = numPad(now.getMinutes());
+        const second = numPad(now.getSeconds());
 
-        var now_ms = now.getMilliseconds();
-        var timeUntilNextSec_ms = 1000 - now_ms;
+        const modelTotalSec = getModelTotalSec(timeMultiplier != 60);
+        const modelHourNum = Math.abs(Math.floor(modelTotalSec / 3600));
+        const modelMinuteNum = Math.abs(Math.floor((modelTotalSec / 60) % 60));
+        const modelHour = numPad(modelHourNum);
+        const modelMinute = numPad(modelMinuteNum);
+
+        document.getElementById('RFCClock').innerHTML = `${modelHour}:${modelMinute}`;
+        document.getElementById('Calendar').innerHTML = `現在時刻 ${year}/${month}/${date} ${hour}:${minute}:${second}`;
+
+        const now_ms = now.getMilliseconds();
+        const timeUntilNextSec_ms = (1000 - now_ms) / (Math.max(timeMultiplier, 60) / 60);
         window.setTimeout("clock()", timeUntilNextSec_ms);
     }
     window.onload = clock;

--- a/js/clock.js
+++ b/js/clock.js
@@ -41,10 +41,13 @@
     function getParamWithLocalStorage(name) {
         const paramValue = getParam(name);
         if (paramValue) {
-            localStorage[name] = paramValue
-            return paramValue
+            console.log(name, paramValue);
+            localStorage[name] = paramValue;
+            return paramValue;
         } else {
-            return localStorage[name]
+            const storedValue = localStorage[name];
+            console.log(name, storedValue, "(stored)");
+            return storedValue;
         }
     }
 
@@ -116,5 +119,12 @@
     }
     window.addEventListener('load', function () {
         clock();
+
+        const rfcLogo = document.getElementById('rfc_logo');
+        rfcLogo.addEventListener('click', function () {
+            // ローカルストレージのキャッシュをリセットし、クエリに指定されたもののみを使用するようにする
+            localStorage.clear();
+            location.reload();
+        });
     })
 }

--- a/js/clock.js
+++ b/js/clock.js
@@ -1,9 +1,17 @@
 {
+    /** (未実装) 模型時刻[秒]単位で、端末時刻からどれくらいずらすか */
+    const PARAM_NAME_DELAY = "delay";
+    /** 表示するイベント種別 (`hanabi`等) */
+    const PARAM_NAME_EVENT = "event";
+    /** 下部に表示する案内メッセージ */
+    const PARAM_NAME_INFOTEXT = "infotext";
+
     /**
      * Get the URL parameter value
      *
      * @param  name {string} パラメータのキー文字列
-     * @return  url {url} 対象のURL文字列（任意）
+     * @param  url {url} 対象のURL文字列（任意）
+     * @returns {string} パラメータの値
      */
     function getParam(name, url) {
         if (!url) url = window.location.href;
@@ -16,13 +24,13 @@
     }
 
     var delay = 0;
-    if (getParam("deley") !== null) {
-        var delay = getParam("deley");
+    if (getParam(PARAM_NAME_DELAY) !== null) {
+        delay = getParam(PARAM_NAME_DELAY);
     }
     //特殊モード（秩父夜祭花火用）
     var event = null;
-    if (getParam("event") !== null) {
-        event = getParam("event");
+    if (getParam(PARAM_NAME_EVENT) !== null) {
+        event = getParam(PARAM_NAME_EVENT);
     }
 
     //打ち上げ開始時刻
@@ -31,8 +39,8 @@
     function clock() {
         var param = location.search;
         var infotext = '';
-        if (getParam("infotext") !== null) {
-            infotext = getParam("infotext");
+        if (getParam(PARAM_NAME_INFOTEXT) !== null) {
+            infotext = getParam(PARAM_NAME_INFOTEXT);
         }
 
         document.getElementById('infotext').innerHTML = decodeURI(infotext);

--- a/js/hanabi.js
+++ b/js/hanabi.js
@@ -22,7 +22,7 @@ function setup() {
 
 function draw() {
     // 背景色を設定
-    if (event == "hanabi") {
+    if (eventMode == "hanabi") {
         //はなびぃ
         setGradient(0, 0, width, height, color(0, 0, 0), color(24, 32, 72), Y_AXIS);
         noStroke();


### PR DESCRIPTION
クエリパラメータを用いて、1日の長さ、および「模型時刻での1秒の長さ = 時間の倍率」を変更できるようにしました。

|name|description||default|
|---:|:---|---:|
|`time-len`|模型時刻での1日の長さ[秒]|`30 * 60 * 60 (= 30時間 = 108000秒)`|
|`time-multiplier`|現実1秒で模型時刻がどれくらい進むか[現実秒]|`60 (= 60倍速)`|

---

ついでに、localStorageにクエリパラメータの各値をキャッシュするようにしました。
一度クエリパラメータ付きで起動させれば、クエリパラメータを指定しなくても前回の設定を読み込みます。

もちろん、localStorageのキャッシュよりもクエリパラメータの指定が優先されます。
`QueryParameter > localStorage > (Default Value)`
といった優先度です。

クエリパラメータのキャッシュをクリアしたい場合、RFCロゴをクリックしてください。
localStorageがクリアされ、画面も再読み込みされます。

---

例として、2024twrの場合は以下のようなURLになります。

https://railway-fan-club.github.io/rfc-clock/?infotext=2024TWR&time-len=36000

(2024twrは1日を10時間としたため、`10 * 60 * 60 = 36,000`です。)

なお、マイナス時間のサポートは面倒なので入れていません。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced clock functionality with improved parameter management and model time calculations.
	- Added utility for formatting numbers with leading zeros.

- **Bug Fixes**
	- Refined event handling mechanism in the drawing logic of the Hanabi game.

- **Refactor**
	- Updated event state management in the Hanabi drawing function for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->